### PR TITLE
made sure we get 8080 as default port, when env err

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -19,8 +20,13 @@ type Server struct {
 }
 
 func NewServer() *http.Server {
-	port, err := strconv.Atoi(os.Getenv("PORT"))
+	envPort := os.Getenv("PORT")
+	if envPort == "" {
+		envPort = "8080"
+	}
+	port, err := strconv.Atoi(envPort)
 	if err != nil {
+		log.Printf("Error converting PORT to integer, using default port 8080: %v", err)
 		port = 8080
 	}
 	NewServer := &Server{


### PR DESCRIPTION
### TL;DR

Added default port and improved error handling for server initialization.

### What changed?

- Introduced a default port (8080) if the PORT environment variable is not set.
- Added error logging when the PORT environment variable cannot be converted to an integer.
- The server now falls back to the default port (8080) in case of conversion errors.

### Why make this change?

This change improves the robustness of the server initialization process by:
1. Ensuring the server always starts, even if the PORT environment variable is not set.
2. Providing better visibility into configuration issues through error logging.
3. Maintaining consistent behavior by defaulting to port 8080 in error scenarios.

These improvements enhance the reliability and user-friendliness of the server setup process.