### PR TITLE
few response structs to keep response schema order

### DIFF
--- a/internal/data/schemas.go
+++ b/internal/data/schemas.go
@@ -44,3 +44,14 @@ type SessionTokens struct {
 	RefreshCreatedAt time.Time `json:"refresh_created_at"`
 	RefreshExpiresAt time.Time `json:"refresh_expires_at"`
 }
+
+type TokenResponse struct {
+	Message string         `json:"message"`
+	Tokens  *SessionTokens `json:"tokens"`
+}
+
+type LoginRegisterResponse struct {
+	Message string         `json:"message"`
+	User    *User          `json:"user"`
+	Tokens  *SessionTokens `json:"tokens"`
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -102,14 +102,7 @@ func (s *Server) Login(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Failed to create session"})
 	}
 
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"message":            "Login successful",
-		"user":               user,
-		"access_token":       tokens.AccessToken,
-		"expires_at":         tokens.AccessExpiresAt,
-		"refresh_token":      tokens.RefreshToken,
-		"refresh_expires_at": tokens.RefreshExpiresAt,
-	})
+	return c.JSON(http.StatusOK, data.LoginRegisterResponse{Message: "Login successful", User: user, Tokens: tokens})
 }
 
 func (s *Server) Register(c echo.Context) error {
@@ -132,14 +125,7 @@ func (s *Server) Register(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": err.Error()})
 	}
 
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"message":            "User created successfully",
-		"user":               user,
-		"access_token":       tokens.AccessToken,
-		"expires_at":         tokens.AccessExpiresAt,
-		"refresh_token":      tokens.RefreshToken,
-		"refresh_expires_at": tokens.RefreshExpiresAt,
-	})
+	return c.JSON(http.StatusOK, data.LoginRegisterResponse{Message: "Registration successful", User: user, Tokens: tokens})
 }
 
 func (s *Server) Update(c echo.Context) error {
@@ -220,13 +206,7 @@ func (s *Server) RefreshTokenHandler(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Failed to generate new access token"})
 	}
 
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"message":            "Token refreshed successfully",
-		"access_token":       tokens.AccessToken,
-		"expires_at":         tokens.AccessExpiresAt,
-		"refresh_token":      tokens.RefreshToken,
-		"refresh_expires_at": tokens.RefreshExpiresAt,
-	})
+	return c.JSON(http.StatusOK, data.TokenResponse{Message: "Token refreshed successfully", Tokens: tokens})
 }
 
 func (s *Server) healthHandler(c echo.Context) error {


### PR DESCRIPTION
### TL;DR

Introduced new response structures and refactored API endpoints to use them.

### What changed?

- Added new `TokenResponse` and `LoginRegisterResponse` structures in `schemas.go`.
- Refactored `Login`, `Register`, and `RefreshTokenHandler` functions in `routes.go` to use the new response structures.
- Simplified JSON responses in these functions by utilizing the new structures.

### Why make this change?

This change standardizes the API responses, making them more consistent and easier to maintain. It also improves code readability and reduces duplication by using structured types instead of inline map declarations for responses. This will make it easier for both the backend developers to manage the code and for frontend developers to work with the API responses.