### PR TITLE
updated go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 WORKDIR /gordian-build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mAmineChniti/Gordian
 
-go 1.23.1
+go 1.23.2
 
 require (
 	github.com/joho/godotenv v1.5.1


### PR DESCRIPTION
### TL;DR

Updated Go version in Dockerfile and go.mod file.

### What changed?

- Updated the Go version in the Dockerfile from 1.22 to 1.23
- Bumped the Go version in go.mod from 1.23.1 to 1.23.2

### Why make this change?

Updating to the latest Go version ensures that we benefit from the latest language features, performance improvements, and bug fixes. This change keeps our development environment and runtime up-to-date with the most recent stable release of Go.