### PR TITLE
added copying and update for ssl certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM golang:1.23 AS builder
 WORKDIR /gordian-build
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends make && \
+    apt-get install -y --no-install-recommends make ca-certificates && \
+    update-ca-certificates && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 COPY go.mod go.sum ./
@@ -17,6 +19,7 @@ FROM scratch
 
 WORKDIR /app
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /gordian-build/main /app/
 
 EXPOSE 8080


### PR DESCRIPTION
### TL;DR

Updated Dockerfile to include SSL certificates and improved image cleanup.

### What changed?

- Added installation of `ca-certificates` in the builder stage
- Added `update-ca-certificates` command to ensure certificates are up-to-date
- Included `apt-get clean` to remove unnecessary package files
- Copied SSL certificates from the builder stage to the final image

### Why make this change?

This change ensures that the application can make secure HTTPS connections by including the necessary SSL certificates. It also improves the Docker image by cleaning up unnecessary files, which helps to keep the image size optimized.