### PR TITLE
updated baseurl to deployed api

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the API documentation for the Gordian API. The API is a RESTful API that
 
 ## Base URL
 
-`https://TBD/api/v1`
+`https://gordian.onrender.com/api/v1`
 
 ## Authentication
 


### PR DESCRIPTION
### TL;DR

Updated the base URL for the Gordian API in the README.md file.

### What changed?

The base URL for the Gordian API has been updated from a placeholder value (`https://TBD/api/v1`) to the actual production URL (`https://gordian.onrender.com/api/v1`).

### Why make this change?

This update provides the correct and functional base URL for the Gordian API, allowing users to accurately interact with the API endpoints. It replaces the placeholder URL with the actual production URL, improving the documentation's accuracy and usefulness for developers integrating with the Gordian API.