### PR TITLE
baseurl url instead of codeblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the API documentation for the Gordian API. The API is a RESTful API that
 
 ## Base URL
 
-`https://gordian.onrender.com/api/v1`
+https://gordian.onrender.com/api/v1
 
 ## Authentication
 


### PR DESCRIPTION
### TL;DR

Updated the base URL formatting in the README.md file.

### What changed?

The base URL in the README.md file has been reformatted from a plain code block to a clickable link using Markdown syntax.

### Why make this change?

This change improves the user experience by making the base URL directly clickable, allowing for easier access to the API endpoint. It also enhances the overall readability and usability of the documentation.