### PR TITLE
changed hashing to maxcost

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -77,7 +77,7 @@ func (s *service) CreateUser(user *data.RegisterRequest) (*data.User, *data.Sess
 	if foundUser > 0 {
 		return nil, nil, fmt.Errorf("user already exists")
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.MaxCost)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to hash password: %v", err)
 	}
@@ -120,7 +120,7 @@ func (s *service) UpdateUser(userID primitive.ObjectID, user *data.UpdateRequest
 		updateFields["last_name"] = user.LastName
 	}
 	if user.Password != "" {
-		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.MaxCost)
 		if err != nil {
 			return nil, fmt.Errorf("password hashing failed: %w", err)
 		}


### PR DESCRIPTION
### TL;DR

Increased password hashing cost from default to maximum for enhanced security.

### What changed?

- Modified the `CreateUser` function to use `bcrypt.MaxCost` instead of `bcrypt.DefaultCost` when hashing new user passwords.
- Updated the `UpdateUser` function to also use `bcrypt.MaxCost` when hashing updated passwords.

### Why make this change?

Using `bcrypt.MaxCost` instead of `bcrypt.DefaultCost` significantly increases the computational effort required to hash passwords. This change enhances security by making it more difficult and time-consuming for potential attackers to crack passwords through brute-force methods. While this may slightly increase the time required for user registration and password updates, it provides a substantial security benefit, especially in protecting high-value user accounts.