### PR TITLE
info instead of warn

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -56,7 +56,7 @@ func DEBUG(e *echo.Echo) {
 					}
 				}
 			} else {
-				c.Logger().Warn("Response Body is empty.")
+				c.Logger().Info("Response Body is empty.")
 			}
 		}))
 	}


### PR DESCRIPTION
### TL;DR

Changed log level for empty response bodies from WARN to INFO.

### What changed?

Modified the logging statement in the DEBUG function to use `c.Logger().Info()` instead of `c.Logger().Warn()` when encountering an empty response body.

### Why make this change?

This change reduces noise in the logs by downgrading the severity of empty response body messages. Empty response bodies are not necessarily a cause for concern and should be treated as informational rather than a warning. This adjustment helps maintain cleaner logs and allows developers to focus on more critical issues.