### PR TITLE
updated go version to 1.23.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.1'
+          go-version: '1.23.4'
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.1'
+          go-version: '1.23.4'
 
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mAmineChniti/Gordian
 
-go 1.23.2
+go 1.23.4
 
 require (
 	github.com/joho/godotenv v1.5.1


### PR DESCRIPTION
### TL;DR
Upgraded Go version from 1.23.1/1.23.2 to 1.23.4 across GitHub Actions workflows and go.mod

### What changed?
- Updated Go version to 1.23.4 in build.yml workflow
- Updated Go version to 1.23.4 in lint-format.yml workflow
- Updated Go version to 1.23.4 in go.mod file

### Why make this change?
Keeping Go version up to date ensures we have the latest security patches, bug fixes, and performance improvements from the 1.23.x release series.