### PR TITLE
bind to 0.0.0.0

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,7 +21,7 @@ type Server struct {
 func NewServer() *http.Server {
 	envPort := os.Getenv("PORT")
 	if envPort == "" {
-		envPort = "8080"
+		envPort = "10000"
 	}
 	port, _ := strconv.Atoi(envPort)
 	NewServer := &Server{
@@ -32,7 +32,7 @@ func NewServer() *http.Server {
 
 	// Declare Server config
 	server := &http.Server{
-		Addr:         fmt.Sprintf(":%d", NewServer.port),
+		Addr:         fmt.Sprintf("0.0.0.0:%d", NewServer.port),
 		Handler:      NewServer.RegisterRoutes(),
 		IdleTimeout:  time.Minute,
 		ReadTimeout:  10 * time.Second,


### PR DESCRIPTION
### TL;DR
Updated server configuration to use port 10000 and explicit IP binding

### What changed?
- Changed default port from 8080 to 10000 when no PORT environment variable is set
- Modified server address binding from `:port` to `0.0.0.0:port` format

### Why make this change?
The explicit IP binding (0.0.0.0) ensures the server listens on all available network interfaces, improving accessibility from external connections. The port change to 10000 may help avoid conflicts with commonly used ports in the 8000 range.