### PR TITLE
login using email or username

### DIFF
--- a/internal/data/schemas.go
+++ b/internal/data/schemas.go
@@ -16,8 +16,8 @@ type User struct {
 }
 
 type LoginRequest struct {
-	Username string `json:"username" validate:"required,min=5"`
-	Password string `json:"password" validate:"required,min=6"`
+	Identifier string `json:"identifier" validate:"required,min=5"`
+	Password   string `json:"password" validate:"required,min=6"`
 }
 
 type RegisterRequest struct {


### PR DESCRIPTION
### TL;DR
Allow users to login with either email or username

### What changed?
- Renamed `username` field to `identifier` in LoginRequest struct to better reflect its dual purpose
- Modified user lookup logic to check if the identifier contains "@" to determine whether to search by email or username
- Added error handling and improved code formatting for better readability

### Why make this change?
To provide users with more flexibility during authentication by allowing them to use either their email address or username to log in. This is a common feature in modern applications that improves user experience by not forcing users to remember which credential they used to register.