### PR TITLE
added jwt auth on user fetching

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
@@ -42,7 +43,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	e.POST("/api/v1/register", s.Register)
 	e.POST("/api/v1/login", s.Login)
 	e.GET("/api/v1/fetchuser", s.FetchUser, s.JWTMiddleware())
-	e.POST("/api/v1/fetchuserbyid", s.FetchUserById)
+	e.POST("/api/v1/fetchuserbyid", s.FetchUserById, s.JWTMiddleware())
 	e.PUT("/api/v1/update", s.Update, s.JWTMiddleware())
 	e.PATCH("/api/v1/update", s.Update, s.JWTMiddleware())
 	e.DELETE("/api/v1/delete", s.Delete, s.JWTMiddleware())
@@ -206,9 +207,21 @@ func (s *Server) FetchUserById(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Internal server error"})
 	}
 
+	type UserResponse struct {
+		Username   string    `json:"username"`
+		FistName   string    `json:"first_name"`
+		LastName   string    `json:"last_name"`
+		DateJoined time.Time `json:"date_joined"`
+	}
+	response := UserResponse{
+		Username:   user.Username,
+		FistName:   user.FirstName,
+		LastName:   user.LastName,
+		DateJoined: user.DateJoined,
+	}
 	return c.JSON(http.StatusOK, map[string]any{
 		"message": "User fetched successfully",
-		"user":    user,
+		"user":    response,
 	})
 }
 


### PR DESCRIPTION
### TL;DR

Added JWT authentication middleware to the `/api/v1/fetchuserbyid` endpoint.

### What changed?

Applied the `s.JWTMiddleware()` to the `fetchuserbyid` API endpoint to ensure that only authenticated users can access this functionality. This brings it in line with other protected endpoints like `fetchuser`, `update`, and `delete`.

### How to test?

1. Try accessing the `/api/v1/fetchuserbyid` endpoint without a valid JWT token
   - Should receive a 401 Unauthorized response
2. Access the endpoint with a valid JWT token
   - Should successfully retrieve user data
3. Verify that existing authenticated flows still work properly

### Why make this change?

This change addresses a security vulnerability where user data could be accessed without proper authentication. By adding the JWT middleware, we ensure that only authenticated users can fetch information about other users, protecting user privacy and preventing potential data exposure.