### PR TITLE
updated golangci-lint version

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.64
 
       - name: Run gofmt
         run: |


### PR DESCRIPTION
### TL;DR

Upgrade golangci-lint from v1.60 to v1.64 in GitHub Actions workflow.

### What changed?

Updated the golangci-lint version in the `.github/workflows/lint-format.yml` file from v1.60 to v1.64.

### Why make this change?

To leverage the latest features, bug fixes, and improvements available in the newer version of golangci-lint, ensuring the project maintains up-to-date code quality standards.