### PR TITLE
entrypoint on dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,4 @@ COPY --from=builder /gordian-build/main /app/
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl --fail http://localhost:8000/api/v1/health || exit 1
-
-CMD ["./main"]
+ENTRYPOINT ["/app/main"]


### PR DESCRIPTION
### TL;DR

Replace CMD with ENTRYPOINT and remove the HEALTHCHECK directive in Dockerfile.

### What changed?

- Removed the HEALTHCHECK directive that was using curl to check the application health at http://localhost:8000/api/v1/health
- Changed the container execution instruction from `CMD ["./main"]` to `ENTRYPOINT ["/app/main"]`, which:
  - Uses the absolute path to the binary
  - Makes the container behave more like an executable

### Why make this change?

Using ENTRYPOINT instead of CMD makes the container behave more like an executable, allowing arguments to be passed directly when running the container. The removal of the HEALTHCHECK simplifies the container configuration, possibly because health checks are being handled externally or through a different mechanism.