### PR TITLE
latest golang-jwt v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/klauspost/compress v1.17.10 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.25.0 h1:5Dh7cjvzR7BRZadnsVOzPhWsrwUr0nmsZJxEAnFLNO8=
 github.com/go-playground/validator/v10 v10.25.0/go.mod h1:GGzBIJMuE98Ic/kJsBXbz1x/7cByt++cQ+YOuDM5wus=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -295,21 +295,26 @@ func (s *Server) JWTMiddleware() echo.MiddlewareFunc {
 			return c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid or expired token"})
 		},
 		SuccessHandler: func(c echo.Context) {
-			token := c.Get("user").(*jwt.Token)
-			claims := token.Claims.(jwt.MapClaims)
-
-			if claims["jti"] != "access" {
-				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token type"}); err != nil {
-					c.Logger().Error("Failed to send response:", err)
-				}
+			token, ok := c.Get("user").(*jwt.Token)
+			if !ok {
+				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Token not found"})
 				return
 			}
 
-			userID, err := primitive.ObjectIDFromHex(claims["sub"].(string))
+			claims, ok := token.Claims.(*jwt.RegisteredClaims)
+			if !ok {
+				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token claims"})
+				return
+			}
+
+			if claims.ID != "access" {
+				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token type"})
+				return
+			}
+
+			userID, err := primitive.ObjectIDFromHex(claims.Subject)
 			if err != nil {
-				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid user in token"}); err != nil {
-					c.Logger().Error("Failed to send response:", err)
-				}
+				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid user in token"})
 				return
 			}
 
@@ -330,21 +335,26 @@ func (s *Server) RefreshTokenMiddleware() echo.MiddlewareFunc {
 			return c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid or expired token"})
 		},
 		SuccessHandler: func(c echo.Context) {
-			token := c.Get("user").(*jwt.Token)
-			claims := token.Claims.(jwt.MapClaims)
-
-			if claims["jti"] != "refresh" {
-				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token type"}); err != nil {
-					c.Logger().Error("Failed to send response:", err)
-				}
+			token, ok := c.Get("user").(*jwt.Token)
+			if !ok {
+				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Token not found"})
 				return
 			}
 
-			userID, err := primitive.ObjectIDFromHex(claims["sub"].(string))
+			claims, ok := token.Claims.(*jwt.RegisteredClaims)
+			if !ok {
+				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token claims"})
+				return
+			}
+
+			if claims.ID != "refresh" {
+				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token type"})
+				return
+			}
+
+			userID, err := primitive.ObjectIDFromHex(claims.Subject)
 			if err != nil {
-				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid user in token"}); err != nil {
-					c.Logger().Error("Failed to send response:", err)
-				}
+				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid user in token"})
 				return
 			}
 


### PR DESCRIPTION
### TL;DR

Upgraded JWT library from v3 to v5 and improved token validation

### What changed?

- Removed the deprecated `github.com/golang-jwt/jwt` v3 dependency
- Updated import to use `github.com/golang-jwt/jwt/v5`
- Refactored JWT middleware to use the new v5 API:
  - Replaced `jwt.MapClaims` with type-safe `jwt.RegisteredClaims`
  - Added proper type assertions with error handling
  - Improved error responses with more specific messages
  - Simplified error handling in token validation

### Why make this change?

The upgrade to JWT v5 provides better type safety and security improvements. The previous implementation used the deprecated v3 library with untyped map claims, which is more error-prone. The new implementation uses proper type assertions and structured claims, making the code more robust and maintainable.