### PR TITLE
fixed linting issue in middleware jwt

### DIFF
--- a/internal/data/schemas.go
+++ b/internal/data/schemas.go
@@ -1,8 +1,9 @@
 package data
 
 import (
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type User struct {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -297,24 +297,32 @@ func (s *Server) JWTMiddleware() echo.MiddlewareFunc {
 		SuccessHandler: func(c echo.Context) {
 			token, ok := c.Get("user").(*jwt.Token)
 			if !ok {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Token not found"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Token not found"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 
 			claims, ok := token.Claims.(*jwt.RegisteredClaims)
 			if !ok {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token claims"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token claims"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 
 			if claims.ID != "access" {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token type"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token type"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 
 			userID, err := primitive.ObjectIDFromHex(claims.Subject)
 			if err != nil {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid user in token"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid user in token"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 
@@ -337,24 +345,32 @@ func (s *Server) RefreshTokenMiddleware() echo.MiddlewareFunc {
 		SuccessHandler: func(c echo.Context) {
 			token, ok := c.Get("user").(*jwt.Token)
 			if !ok {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Token not found"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Token not found"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 
 			claims, ok := token.Claims.(*jwt.RegisteredClaims)
 			if !ok {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token claims"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token claims"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 
 			if claims.ID != "refresh" {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token type"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid token type"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 
 			userID, err := primitive.ObjectIDFromHex(claims.Subject)
 			if err != nil {
-				c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid user in token"})
+				if err := c.JSON(http.StatusUnauthorized, map[string]string{"message": "Invalid user in token"}); err != nil {
+					c.Logger().Error("failed to send response: ", err)
+				}
 				return
 			}
 


### PR DESCRIPTION
### TL;DR

Added error logging for JSON response failures in JWT middleware handlers.

### What changed?

Enhanced the JWT and Refresh Token middleware handlers to properly log errors that might occur when sending JSON responses to clients. Previously, the code was calling `c.JSON()` without checking for errors, which could lead to silent failures. Now, each JSON response is wrapped in an error check that logs any failures to the Echo logger.

### Why make this change?

This change improves observability by ensuring that any errors occurring during response generation are properly logged. Without this change, if the server encountered issues while sending error responses to clients, these problems would go undetected, potentially making debugging more difficult. This is especially important for authentication-related errors where proper error handling is critical for security.