### PR TITLE
tryna fix jwt middlewares

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -189,6 +189,7 @@ func (s *service) DeleteUser(userID primitive.ObjectID) error {
 
 	return nil
 }
+
 func (s *service) CreateSession(userID primitive.ObjectID) (*data.SessionTokens, error) {
 	now := time.Now()
 


### PR DESCRIPTION
### TL;DR

Refactored JWT middleware implementation to improve token validation and error handling.

### What changed?

- Replaced the generic JWT middleware with custom `ParseTokenFunc` implementations for both access and refresh tokens
- Improved token validation by explicitly checking token type (access vs refresh)
- Enhanced error messages with more specific details about validation failures
- Simplified the middleware code by removing the separate `handleValidToken` and `jwtErrorHandler` functions
- Reorganized the order of handler functions for better readability

### Why make this change?

The previous implementation had separate validation logic that was called after token parsing. This refactoring consolidates the validation into the token parsing step, making the code more maintainable and providing more specific error messages to clients. It also improves security by performing stricter validation of token types and user IDs.