### PR TITLE
prolongue token to 24hrs

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -195,7 +195,7 @@ func (s *service) CreateSession(userID primitive.ObjectID) (*data.SessionTokens,
 
 	accessClaims := &jwt.RegisteredClaims{
 		Subject:   userID.Hex(),
-		ExpiresAt: jwt.NewNumericDate(now.Add(15 * time.Minute)),
+		ExpiresAt: jwt.NewNumericDate(now.Add(24 * time.Hour)),
 		IssuedAt:  jwt.NewNumericDate(now),
 		ID:        "access",
 	}


### PR DESCRIPTION
### TL;DR

Increased access token expiration time from 15 minutes to 24 hours.

### What changed?

Modified the JWT access token expiration time in the `CreateSession` function from 15 minutes to 24 hours to provide users with a longer session duration before requiring re-authentication.

### Why make this change?

The 15-minute token expiration was too short for typical user sessions, causing frequent re-authentication prompts and degrading user experience. The 24-hour duration provides a better balance between security and convenience, allowing users to maintain their session throughout a full day of activity.