### PR TITLE
internal server error on update

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -163,11 +163,7 @@ func (s *service) UpdateUser(userID primitive.ObjectID, user *data.UpdateRequest
 		updateFields["hash"] = hashedPassword
 	}
 	if user.Birthdate != "" {
-		birthdate, err := time.Parse("02/01/2006", user.Birthdate)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse birthdate: %w", err)
-		}
-		updateFields["birthdate"] = birthdate
+		updateFields["birthdate"] = user.Birthdate
 	}
 
 	if len(updateFields) == 0 {


### PR DESCRIPTION
### TL;DR

Simplified user birthdate handling by storing it as a string instead of parsing it to a time.Time object.

### What changed?

Modified the `UpdateUser` function in the database service to store the birthdate directly as a string rather than parsing it into a time.Time object. This removes the parsing logic and potential error handling that was previously required.

### Why make this change?

This change simplifies the code and makes the data model more consistent. It eliminates potential parsing errors and allows for more flexible birthdate formats. The application can now handle the date formatting at the presentation layer rather than enforcing a specific format at the database level.