### PR TITLE
parse on update the birthdate as time.Time, (add constraint at changing birthdate more than 3 times)

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -163,7 +163,11 @@ func (s *service) UpdateUser(userID primitive.ObjectID, user *data.UpdateRequest
 		updateFields["hash"] = hashedPassword
 	}
 	if user.Birthdate != "" {
-		updateFields["birthdate"] = user.Birthdate
+		birthdate, err := time.Parse("02/01/2006", user.Birthdate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse birthdate: %w", err)
+		}
+		updateFields["birthdate"] = birthdate
 	}
 
 	if len(updateFields) == 0 {


### PR DESCRIPTION
### TL;DR

Added proper date parsing for user birthdate updates.

### What changed?

Modified the `UpdateUser` function in the database service to properly parse the birthdate string into a time.Time object before storing it in the database. The function now parses dates in the format "DD/MM/YYYY" and returns an error if the date format is invalid.

### Why make this change?

Previously, the birthdate was stored as a string, which could lead to inconsistent date formats in the database and make date-based queries difficult. This change ensures all birthdates are stored as proper time.Time objects, making them consistent and queryable.