### PR TITLE
added html page to be displayed when confirming email

### DIFF
--- a/internal/data/schemas.go
+++ b/internal/data/schemas.go
@@ -15,7 +15,7 @@ type User struct {
 	LastName                  string             `json:"last_name" bson:"last_name"`
 	Birthdate                 time.Time          `json:"birthdate" bson:"birthdate"`
 	DateJoined                time.Time          `json:"date_joined" bson:"date_joined"`
-	EmailConfirmed            bool               `json:"-" bson:"email_confirmed"`
+	EmailConfirmed            bool               `json:"email_confirmed" bson:"email_confirmed"`
 	EmailToken                string             `json:"-" bson:"email_token"`
 	EmailConfirmationAttempts int                `json:"-" bson:"email_confirmation_attempts"`
 	LastEmailAttemptTime      time.Time          `json:"-" bson:"last_email_attempt_time"`

--- a/internal/templates/email_confirmation.html
+++ b/internal/templates/email_confirmation.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gordian - Email Confirmation</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --primary-color: #3498db;
+            --success-color: #2ecc71;
+            --error-color: #e74c3c;
+            --background-color: #f4f6f9;
+            --text-color: #2c3e50;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+            line-height: 1.6;
+            background-color: var(--background-color);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            color: var(--text-color);
+        }
+
+        .container {
+            background-color: white;
+            border-radius: 12px;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+            padding: 40px;
+            text-align: center;
+            max-width: 500px;
+            width: 100%;
+            transition: transform 0.3s ease;
+        }
+
+        .container:hover {
+            transform: translateY(-5px);
+        }
+
+        .icon {
+            font-size: 72px;
+            margin-bottom: 20px;
+        }
+
+        .success .icon {
+            color: var(--success-color);
+            animation: bounce 1s ease;
+        }
+
+        .error .icon {
+            color: var(--error-color);
+            animation: shake 0.5s ease;
+        }
+
+        h1 {
+            margin-bottom: 15px;
+            font-weight: 600;
+        }
+
+        p {
+            color: #6c757d;
+            margin-bottom: 20px;
+        }
+
+        @keyframes bounce {
+            0%, 20%, 50%, 80%, 100% {transform: translateY(0);}
+            40% {transform: translateY(-20px);}
+            60% {transform: translateY(-10px);}
+        }
+
+        @keyframes shake {
+            0%, 100% {transform: translateX(0);}
+            10%, 30%, 50%, 70%, 90% {transform: translateX(-10px);}
+            20%, 40%, 60%, 80% {transform: translateX(10px);}
+        }
+
+        @media (max-width: 600px) {
+            .container {
+                margin: 20px;
+                padding: 30px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container {{if .Success}}success{{else}}error{{end}}">
+        <div class="icon">
+            {{if .Success}}✓{{else}}✗{{end}}
+        </div>
+        {{if .Success}}
+            <h1>Email Confirmed!</h1>
+            <p>Your email has been successfully confirmed.</p>
+        {{else}}
+            <h1>Email Confirmation Failed</h1>
+            <p>{{.ErrorMessage}}</p>
+        {{end}}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
### TL;DR

Improved email confirmation flow with HTML template and simplified user registration process.

### What changed?

- Exposed `email_confirmed` field in the User JSON response
- Modified `CreateUser` function to no longer return user data and tokens
- Enhanced `ConfirmEmail` function to return success status and error message instead of errors
- Updated the registration endpoint to return a simple success message
- Added an HTML template for email confirmation responses
- Removed automatic session creation during registration
- Fixed email confirmation logic to properly handle already confirmed emails

### Why make this change?

This change improves the user experience during email confirmation by providing a proper HTML response page instead of raw JSON. It also simplifies the registration flow by separating account creation from authentication, requiring users to confirm their email before being able to log in. This enhances security and ensures we have verified user emails before allowing access to the system.