### PR TITLE
i guess we fixed it by fixing the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /app
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /gordian-build/main /app/
+COPY --from=builder /gordian-build/internal/templates /app/internal/templates
 
 EXPOSE 8080
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -43,27 +43,24 @@ type TemplateRenderer struct {
 	templates *template.Template
 }
 
+func NewTemplateRenderer() *TemplateRenderer {
+	emailConfirmationPath := findTemplateFile("email_confirmation.html")
+	tmpl, err := template.ParseFiles(emailConfirmationPath)
+	if err != nil {
+		log.Fatalf("Failed to parse email confirmation template: %v", err)
+	}
+
+	return &TemplateRenderer{
+		templates: tmpl,
+	}
+}
+
 func (t *TemplateRenderer) Render(w io.Writer, name string, data any, c echo.Context) error {
-	// Ensure the template name matches the filename
 	if name == "" {
 		name = "email_confirmation.html"
 	}
 
-	// Find the template by name
-	tmpl := t.templates.Lookup(name)
-	if tmpl == nil {
-		return fmt.Errorf("template %s not found", name)
-	}
-
-	return tmpl.Execute(w, data)
-}
-
-func NewTemplateRenderer() *TemplateRenderer {
-	tmplPath := findTemplateFile("email_confirmation.html")
-	tmpl := template.Must(template.ParseFiles(tmplPath))
-	return &TemplateRenderer{
-		templates: tmpl,
-	}
+	return t.templates.ExecuteTemplate(w, name, data)
 }
 
 func (s *Server) RegisterRoutes() http.Handler {


### PR DESCRIPTION
### TL;DR

Fixed template rendering in Docker container by copying template files and improving template handling.

### What changed?

- Added a step in the Dockerfile to copy the `/internal/templates` directory from the builder stage to the final container
- Refactored the `TemplateRenderer` implementation:
  - Improved error handling in `NewTemplateRenderer()` with proper fatal logging
  - Simplified the `Render()` method to use `ExecuteTemplate()` instead of looking up the template first

### Why make this change?

The application was likely failing to render templates in the Docker container because the template files weren't being copied to the final image. This change ensures the templates are available at runtime and improves the template rendering logic for better error handling and simpler execution.