### PR TITLE
tryna make the email format better

### DIFF
--- a/internal/services/email.go
+++ b/internal/services/email.go
@@ -108,9 +108,12 @@ func (s *GmailSMTPEmailService) SendConfirmationEmail(email, token string) error
 </html>
 `, confirmationLink)
 
-	subject := "Subject: Confirm Your Gordian Account\n"
-	mime := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
-	body := subject + mime + htmlBody
+	fromHeader := fmt.Sprintf("From: Gordian <%s>\r\n", s.from)
+	toHeader := fmt.Sprintf("To: %s\r\n", email)
+	subject := "Subject: Confirm Your Gordian Account\r\n"
+	mime := "MIME-version: 1.0;\r\nContent-Type: text/html; charset=\"UTF-8\";\r\n\r\n"
+
+	body := fromHeader + toHeader + subject + mime + htmlBody
 
 	auth := smtp.PlainAuth("", s.from, s.password, s.smtpHost)
 


### PR DESCRIPTION
### TL;DR

Added proper email headers to confirmation emails.

### What changed?

Enhanced the `SendConfirmationEmail` function in the `GmailSMTPEmailService` by adding proper email headers:
- Added a "From" header with the sender's email address
- Added a "To" header with the recipient's email address
- Formatted the headers with proper line endings (`\r\n`)
- Incorporated these new headers into the email body

### Why make this change?

Proper email headers are essential for email deliverability and display. Without the "From" and "To" headers, emails may be marked as spam or display incorrectly in email clients. This change ensures our confirmation emails follow email standards and have a higher chance of reaching users' inboxes.