### PR TITLE
avoid repeating 0 ids

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -126,6 +126,7 @@ func (s *service) CreateUser(user *data.RegisterRequest) error {
 	emailToken := uuid.New().String()
 
 	endUser := data.User{
+		ID:                        primitive.NewObjectID(),
 		Username:                  user.Username,
 		Email:                     user.Email,
 		Hash:                      string(hash),


### PR DESCRIPTION
### TL;DR

Added explicit ID assignment when creating a new user.

### What changed?

Added a line to assign a new `primitive.ObjectID` to the `ID` field of a `data.User` struct during user creation in the `CreateUser` method.

### Why make this change?

Previously, the ID field was not explicitly set during user creation, which could lead to MongoDB assigning IDs automatically or potential issues with ID consistency. By explicitly generating and assigning a new ObjectID, we ensure consistent ID generation and better control over the user creation process.