### PR TITLE
changed route name

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -102,7 +102,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	e.DELETE("/api/v1/delete", s.Delete, s.JWTMiddleware())
 	e.GET("/api/v1/refresh", s.RefreshTokenHandler, s.RefreshTokenMiddleware())
 	e.GET("/api/v1/health", s.healthHandler)
-	e.GET("/api/v1/confirm-email", s.reConfirmEmail, s.JWTMiddleware())
+	e.GET("/api/v1/resend-confirmation-email", s.reConfirmEmail, s.JWTMiddleware())
 	e.GET("/api/v1/confirm-email/:token", s.ConfirmEmail)
 	e.RouteNotFound("/*", func(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, map[string]string{


### PR DESCRIPTION
### TL;DR

Updated the email confirmation endpoint URL to better reflect its functionality.

### What changed?

Changed the endpoint URL from `/api/v1/confirm-email` to `/api/v1/resend-confirmation-email` for the `reConfirmEmail` handler function. The JWT middleware requirement remains unchanged.

### Why make this change?

The new endpoint name more accurately describes the functionality of the endpoint, which is to resend a confirmation email rather than to confirm an email address directly. This improves API clarity and makes the distinction clearer between this endpoint and the `/api/v1/confirm-email/:token` endpoint which actually performs the confirmation.