### PR TITLE
added clear too many requests msg

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -249,6 +249,11 @@ func (s *Server) reConfirmEmail(c echo.Context) error {
 				"message": "User profile not found",
 			})
 		}
+		if strings.Contains(err.Error(), "please wait 5 minutes before requesting another confirmation email") {
+			return c.JSON(http.StatusTooManyRequests, map[string]string{
+				"message": "Please wait 5 minutes before requesting another confirmation email",
+			})
+		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"message": "Unable to resend confirmation email",
 		})


### PR DESCRIPTION
### TL;DR

Added rate limiting error handling for email confirmation requests.

### What changed?

Added a specific error handler in the `reConfirmEmail` function that checks if the error message contains "please wait 5 minutes before requesting another confirmation email". When this error is detected, the server now returns a 429 (Too Many Requests) status code with an appropriate message to the client.

### Why make this change?

This change improves the user experience by providing clear feedback when users attempt to request multiple confirmation emails in a short period. It also helps prevent email service abuse by enforcing the existing rate limit with a proper HTTP status code and message.