### PR TITLE
added accept_terms on register

### DIFF
--- a/internal/data/schemas.go
+++ b/internal/data/schemas.go
@@ -19,8 +19,9 @@ type User struct {
 	EmailToken                string             `json:"-" bson:"email_token"`
 	EmailConfirmationAttempts int                `json:"-" bson:"email_confirmation_attempts"`
 	LastEmailAttemptTime      time.Time          `json:"-" bson:"last_email_attempt_time"`
-	PasswordResetToken        string             `bson:"password_reset_token,omitempty"`
-	PasswordResetExpiry       time.Time          `bson:"password_reset_expiry,omitempty"`
+	PasswordResetToken        string             `json:"-" bson:"password_reset_token,omitempty"`
+	PasswordResetExpiry       time.Time          `json:"-" bson:"password_reset_expiry,omitempty"`
+	AcceptTerms               bool               `json:"-" bson:"accept_terms"`
 }
 
 type LoginRequest struct {
@@ -29,12 +30,13 @@ type LoginRequest struct {
 }
 
 type RegisterRequest struct {
-	Username  string `json:"username" validate:"required,min=5"`
-	Email     string `json:"email" validate:"required,email"`
-	Password  string `json:"password" validate:"required,min=6"`
-	FirstName string `json:"first_name" validate:"required,min=3"`
-	LastName  string `json:"last_name" validate:"required,min=3"`
-	Birthdate string `json:"birthdate" validate:"required,birthdate"`
+	Username    string `json:"username" validate:"required,min=5"`
+	Email       string `json:"email" validate:"required,email"`
+	Password    string `json:"password" validate:"required,min=6"`
+	FirstName   string `json:"first_name" validate:"required,min=3"`
+	LastName    string `json:"last_name" validate:"required,min=3"`
+	Birthdate   string `json:"birthdate" validate:"required,birthdate"`
+	AcceptTerms bool   `json:"accept_terms" validate:"required,eq=true"`
 }
 
 type UpdateRequest struct {


### PR DESCRIPTION
### TL;DR

Added terms acceptance requirement for user registration

### What changed?

- Added `AcceptTerms` boolean field to the `User` struct with JSON exclusion and BSON mapping
- Added `AcceptTerms` field to the `RegisterRequest` struct with validation requiring it to be true
- Added JSON exclusion tags to `PasswordResetToken` and `PasswordResetExpiry` fields to prevent them from being exposed in API responses

### Why make this change?

This change enhances user privacy by preventing sensitive password reset information from being exposed in API responses. It also adds a required terms acceptance field to ensure users explicitly agree to terms of service before registration, which is important for legal compliance.