### PR TITLE
fixing email unconfirmed delete

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -345,7 +345,7 @@ func (s *service) DeleteUnconfirmedUsers() error {
 	deleteFilter := bson.M{
 		"email_confirmed": false,
 		"date_joined": bson.M{
-			"$lte": time.Now().AddDate(0, 0, -3),
+			"$lt": time.Now().AddDate(0, 0, -3),
 		},
 	}
 


### PR DESCRIPTION
### TL;DR

Fixed a date comparison operator in the unconfirmed user deletion query.

### What changed?

Changed the date comparison operator from `$lte` (less than or equal to) to `$lt` (less than) in the `DeleteUnconfirmedUsers` function. This affects how we filter unconfirmed users based on their join date.

### Why make this change?

The previous implementation using `$lte` would delete users who registered exactly 3 days ago. The new implementation with `$lt` ensures we only delete users who registered more than 3 days ago, giving users a full 3 days to confirm their email before deletion.