### PR TITLE
run delete every 6 hrs

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -42,7 +42,7 @@ func main() {
 	dbService := database.New()
 
 	go func() {
-		ticker := time.NewTicker(24 * time.Hour)
+		ticker := time.NewTicker(6 * time.Hour)
 		defer ticker.Stop()
 
 		for range ticker.C {


### PR DESCRIPTION
### TL;DR

Reduced the database service ticker interval from 24 hours to 6 hours.

### What changed?

Modified the ticker interval in the goroutine that periodically triggers the database service from 24 hours to 6 hours, allowing for more frequent execution of the database operations.

### Why make this change?

The more frequent interval allows for better data synchronization and reduces the time window between database operations, which improves data freshness and system responsiveness.