### PR TITLE
added profile picture

### DIFF
--- a/internal/data/schemas.go
+++ b/internal/data/schemas.go
@@ -14,6 +14,7 @@ type User struct {
 	FirstName                 string             `json:"first_name" bson:"first_name"`
 	LastName                  string             `json:"last_name" bson:"last_name"`
 	Birthdate                 time.Time          `json:"birthdate" bson:"birthdate"`
+	ProfilePicture            string             `json:"profile_picture" bson:"profile_picture"`
 	EmailConfirmed            bool               `json:"email_confirmed" bson:"email_confirmed"`
 	AcceptTerms               bool               `json:"accept_terms" bson:"accept_terms"`
 	DateJoined                time.Time          `json:"date_joined" bson:"date_joined"`
@@ -30,22 +31,24 @@ type LoginRequest struct {
 }
 
 type RegisterRequest struct {
-	Username    string `json:"username" validate:"required,min=5,max=20"`
-	Email       string `json:"email" validate:"required,email"`
-	Password    string `json:"password" validate:"required,password_complexity"`
-	FirstName   string `json:"first_name" validate:"required,min=2,max=50"`
-	LastName    string `json:"last_name" validate:"required,min=2,max=50"`
-	Birthdate   string `json:"birthdate" validate:"required,rfc3339"`
-	AcceptTerms bool   `json:"accept_terms" validate:"required,eq=true"`
+	Username       string `json:"username" validate:"required,min=5,max=20"`
+	Email          string `json:"email" validate:"required,email"`
+	Password       string `json:"password" validate:"required,password_complexity"`
+	FirstName      string `json:"first_name" validate:"required,min=2,max=50"`
+	LastName       string `json:"last_name" validate:"required,min=2,max=50"`
+	Birthdate      string `json:"birthdate" validate:"required,rfc3339"`
+	AcceptTerms    bool   `json:"accept_terms" validate:"required,eq=true"`
+	ProfilePicture string `json:"profile_picture,omitempty" validate:"omitempty,base64_max_10mb"`
 }
 
 type UpdateRequest struct {
-	Username  string `json:"username,omitempty" validate:"omitempty,min=5,max=20"`
-	Email     string `json:"email,omitempty" validate:"omitempty,email"`
-	Password  string `json:"password,omitempty" validate:"omitempty,password_complexity"`
-	FirstName string `json:"first_name,omitempty" validate:"omitempty,min=2,max=50"`
-	LastName  string `json:"last_name,omitempty" validate:"omitempty,min=2,max=50"`
-	Birthdate string `json:"birthdate,omitempty" validate:"omitempty,rfc3339"`
+	Username       string `json:"username,omitempty" validate:"omitempty,min=5,max=20"`
+	Email          string `json:"email,omitempty" validate:"omitempty,email"`
+	Password       string `json:"password,omitempty" validate:"omitempty,password_complexity"`
+	FirstName      string `json:"first_name,omitempty" validate:"omitempty,min=2,max=50"`
+	LastName       string `json:"last_name,omitempty" validate:"omitempty,min=2,max=50"`
+	Birthdate      string `json:"birthdate,omitempty" validate:"omitempty,rfc3339"`
+	ProfilePicture string `json:"profile_picture,omitempty" validate:"omitempty,base64_max_10mb"`
 }
 
 type SessionTokens struct {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -138,6 +138,7 @@ func (s *service) CreateUser(user *data.RegisterRequest) error {
 		EmailConfirmationAttempts: 1,
 		LastEmailAttemptTime:      time.Now(),
 		AcceptTerms:               user.AcceptTerms,
+		ProfilePicture:            user.ProfilePicture,
 	}
 	_, err = s.db.Database("gordian").Collection("users").InsertOne(ctx, endUser)
 	if err != nil {
@@ -181,6 +182,9 @@ func (s *service) UpdateUser(userID primitive.ObjectID, user *data.UpdateRequest
 			return nil, fmt.Errorf("failed to parse birthdate: %v", err)
 		}
 		updateFields["birthdate"] = birthdate
+	}
+	if user.ProfilePicture != "" {
+		updateFields["profile_picture"] = user.ProfilePicture
 	}
 
 	if len(updateFields) == 0 {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -204,7 +204,11 @@ func (s *Server) Login(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Unable to create session"})
 	}
 
-	return c.JSON(http.StatusOK, data.LoginRegisterResponse{Message: "Login successful", User: user, Tokens: tokens})
+	return c.JSON(http.StatusOK, data.LoginRegisterResponse{
+		Message: "Login successful",
+		User:    user,
+		Tokens:  tokens,
+	})
 }
 
 func (s *Server) ConfirmEmail(c echo.Context) error {
@@ -369,7 +373,8 @@ func (s *Server) Update(c echo.Context) error {
 
 		case strings.Contains(errStr, "failed to update user"):
 			return c.JSON(http.StatusInternalServerError, map[string]string{"message": "An error occurred while updating your profile"})
-
+		case strings.Contains(errStr, "failed to update profile picture"):
+			return c.JSON(http.StatusInternalServerError, map[string]string{"message": "An error occurred while updating your profile picture"})
 		default:
 			return c.JSON(http.StatusInternalServerError, map[string]string{"message": "Unexpected error during profile update"})
 		}


### PR DESCRIPTION
### TL;DR

Added profile picture support to user accounts.

### What changed?

- Added `ProfilePicture` field to the `User` struct
- Extended `RegisterRequest` and `UpdateRequest` structs to include optional profile picture data
- Created a new validator `base64_max_10mb` to ensure profile pictures don't exceed 10MB
- Updated database operations to handle storing and updating profile pictures
- Enhanced error handling for profile picture-related operations

### Why make this change?

This enhancement allows users to personalize their accounts with profile pictures, improving the user experience and making the platform more engaging. The implementation uses base64 encoding with size validation to ensure efficient storage and prevent abuse.