### PR TITLE
removed deprecated method

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -26,7 +26,7 @@ var (
 
 func (s *Server) RegisterRoutes() http.Handler {
 	e := echo.New()
-	e.Use(middleware.Logger())
+	e.Use(middleware.RequestLoggerWithConfig())
 	e.Use(middleware.Recover())
 
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
@@ -38,7 +38,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	}))
 
 	e.Logger.SetLevel(log.DEBUG)
-	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+	e.Use(middleware.RequestLoggerWithConfig(middleware.LoggerConfig{
 		Format: "method=${method}, uri=${uri}, status=${status}\n",
 	}))
 


### PR DESCRIPTION
### TL;DR

Updated the logging middleware in the server routes to use RequestLoggerWithConfig.

### What changed?

- Replaced `middleware.Logger()` with `middleware.RequestLoggerWithConfig()`
- Updated `middleware.LoggerWithConfig()` to `middleware.RequestLoggerWithConfig()` to use the newer API

### Why make this change?

This change updates the code to use the newer Echo framework logging middleware API. The RequestLoggerWithConfig provides more flexibility and is the recommended approach for configuring request logging in newer versions of the Echo framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the internal request logging middleware initialization to use a more robust configuration handling approach, while maintaining consistent logging output and format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->