### PR TITLE
updated go ver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Setup Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24.0'
+          go-version: '1.25.5'
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -14,17 +14,17 @@ jobs:
 
     steps:
       - name: Setup Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24.0'
+          go-version: '1.25.5'
 
       - name: Setup golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: latest
 
       - name: Run gofmt
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder
+FROM golang:1.25.5 AS builder
 
 WORKDIR /gordian-build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mAmineChniti/Gordian
 
-go 1.24.0
+go 1.25.5
 
 require (
 	github.com/go-playground/validator/v10 v10.28.0

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -26,7 +26,6 @@ var (
 
 func (s *Server) RegisterRoutes() http.Handler {
 	e := echo.New()
-	e.Use(middleware.RequestLoggerWithConfig())
 	e.Use(middleware.Recover())
 
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
@@ -38,8 +37,14 @@ func (s *Server) RegisterRoutes() http.Handler {
 	}))
 
 	e.Logger.SetLevel(log.DEBUG)
-	e.Use(middleware.RequestLoggerWithConfig(middleware.LoggerConfig{
-		Format: "method=${method}, uri=${uri}, status=${status}\n",
+	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+		LogStatus: true,
+		LogURI:    true,
+		LogMethod: true,
+		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
+			c.Logger().Infof("method=%s, uri=%s, status=%d", v.Method, v.URI, v.Status)
+			return nil
+		},
 	}))
 
 	e.Renderer = NewTemplateRenderer()


### PR DESCRIPTION
### TL;DR

Upgrade Go version to 1.25.5 and update GitHub Actions dependencies.

### What changed?

- Updated Go version from 1.24.0 to 1.25.5 across all files:
  - GitHub workflows
  - Dockerfile
  - go.mod
- Upgraded GitHub Actions:
  - actions/checkout from v4 to v6
  - actions/setup-go from v5 to v6
  - golangci/golangci-lint-action from v6 to v7 with version set to "latest"
- Improved Echo middleware logging configuration:
  - Removed redundant middleware.RequestLoggerWithConfig() call
  - Updated to use RequestLoggerConfig with LogValuesFunc for better log formatting

### Why make this change?

Keeping dependencies up-to-date improves security and allows us to leverage new features and performance improvements in Go 1.25.5. The logging middleware changes provide more structured and readable logs while eliminating redundant configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.25.5 across build, Docker, and CI environments
  * Upgraded GitHub Actions workflows to latest compatible versions for improved reliability
  * Updated Docker base image to match Go toolchain version

* **Improvements**
  * Enhanced request logging to capture HTTP method, URI, and status information

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->