### PR TITLE
swagger docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is the API documentation for the Gordian API. The API is a RESTful API that
 
 https://gordian.onrender.com/api/v1
 
+## API Documentation UI
+
+- The interactive Swagger UI is exposed at the `/docs` route under the API base path. For example, visit `https://gordian.onrender.com/api/v1/docs` to view the API documentation and try endpoints.
+
 ## Authentication
 
 Protected routes require a valid JWT token in the Authorization header as a Bearer token.


### PR DESCRIPTION
### TL;DR

Added information about the Swagger UI documentation endpoint to the README.

### What changed?

Added a new section titled "API Documentation UI" to the README that informs users about the interactive Swagger UI available at the `/docs` route. The section includes an example URL (`https://gordian.onrender.com/api/v1/docs`) where users can view the API documentation and try endpoints.

### Why make this change?

To improve developer experience by making it clear how to access the interactive API documentation. This helps users discover and understand the available endpoints more easily, reducing the learning curve for new developers working with the Gordian API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to include information about accessing the interactive API interface through Swagger UI at the designated documentation endpoint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->